### PR TITLE
Add Scikit-rf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1045,6 +1045,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [statsmodels](https://github.com/statsmodels/statsmodels) - Statistical modeling and econometrics in Python.
 * [SymPy](https://github.com/sympy/sympy) - A Python library for symbolic mathematics.
 * [Zipline](https://github.com/quantopian/zipline) - A Pythonic algorithmic trading library.
+* [Scikit-rf](https://github.com/scikit-rf/scikit-rf) - A Python library for RF/Microwave Engineering
 
 ## Search
 


### PR DESCRIPTION
Provides a comprehensive set of tools to perform computations for radio-frequency (RF) and microwave engineering, RF network and data analysis.

## What is this Python project?

The project provides common calculations and analysis tools required in microwave and RF engineering. This library can be used to perform scientific computation in the fields integrated circuits, high speed digital networks, waveguides and even optics. It is considered the go-to package in the industry when python is required to be used.

## What's the difference between this Python project and similar ones?

To my knowledge, this is the only fully functional and actively maintained python package for RF/Microwave engineering. There is nothing else out there which provides all the functionality that this library does.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
